### PR TITLE
Issue #7: Added "Add new link"

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
 <script src="app.js" type="text/javascript"></script>
+  <a href = "https://github.com/marco-c/code-coverage-reports/issues/new">New issue</a>
 <input type="checkbox" name="third_party" id="third_party" checked="checked"><label for="third_party">Show third-party files</label>
 <input type="checkbox" name="headers" id="headers"><label for="headers">Show headers</label>
 <input type="checkbox" name="completely_uncovered" id="completely_uncovered"><label for="completely_uncovered">Show completely uncovered files only</label>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <br />
 <div id="output">
 </div>
+<br />
 <a href = "https://github.com/marco-c/code-coverage-reports/issues/new">Report an issue</a>
-
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,6 @@
 <div id="output">
 </div>
 <br />
-<a href = "https://github.com/marco-c/code-coverage-reports/issues/new">Report an issue</a>
+<a href="https://github.com/marco-c/code-coverage-reports/issues/new">Report an issue</a>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
 </head>
 <body>
 <script src="app.js" type="text/javascript"></script>
-  <a href = "https://github.com/marco-c/code-coverage-reports/issues/new">New issue</a>
+<a href = "https://github.com/marco-c/code-coverage-reports/issues/new">Add new issue</a>
+<br>
 <input type="checkbox" name="third_party" id="third_party" checked="checked"><label for="third_party">Show third-party files</label>
 <input type="checkbox" name="headers" id="headers"><label for="headers">Show headers</label>
 <input type="checkbox" name="completely_uncovered" id="completely_uncovered"><label for="completely_uncovered">Show completely uncovered files only</label>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,6 @@
 </head>
 <body>
 <script src="app.js" type="text/javascript"></script>
-<a href = "https://github.com/marco-c/code-coverage-reports/issues/new">Add new issue</a>
-<br>
 <input type="checkbox" name="third_party" id="third_party" checked="checked"><label for="third_party">Show third-party files</label>
 <input type="checkbox" name="headers" id="headers"><label for="headers">Show headers</label>
 <input type="checkbox" name="completely_uncovered" id="completely_uncovered"><label for="completely_uncovered">Show completely uncovered files only</label>
@@ -17,5 +15,7 @@
 <br />
 <div id="output">
 </div>
+<a href = "https://github.com/marco-c/code-coverage-reports/issues/new">Report an issue</a>
+
 </body>
 </html>


### PR DESCRIPTION
Fixes #7.

I have added "Add new link" functionality. It was successfully built on Github Pages. It redirects user to the "New Issue" form of this repository. https://rhcu.github.io/code-coverage-reports/